### PR TITLE
Force EOL format to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
Cloning this repo on a Windows machine will use CRLF as EOL characters, which will cause errors when copied to unix system:

```
./bos_accounting.sh: line 19: $'\r': command not found
./bos_accounting.sh: line 21: $'\r': command not found
./bos_accounting.sh: line 74: syntax error: unexpected end of file
```