### PR TITLE
Dealing with leading zero to remove octal number error

### DIFF
--- a/bos_accounting.sh
+++ b/bos_accounting.sh
@@ -112,7 +112,7 @@ k_netearned=`printf "%08d" $((10#$c_earned-10#$d_paid-10#$e_chainpaid))`
 # Print year, time, local channel balance, forwarded amount, % forwarded, fees earned ppm, fees paid ppm, fees net ppm, amount fees earned, amount fees paid, amount chain fees, amount fees net
 #
 printf "%(%Y-%m-%d)T    %(%T)T";
-printf "%#13d%#12d" $a_local $b_routed;
+printf "%#13d%#12d" $((10#$a_local)) $((10#$b_routed));
 printf "   %#6.2f%%" $f_pcrouted;
 printf "   %4d ppm %4d ppm %4d ppm" $g_ppmearned $h_ppmpaid $i_ppmnet;
 printf "   "$c_earned"    -"$d_paid"    -"$e_chainpaid"    "$k_netearned;


### PR DESCRIPTION
line 115 needs to convert to base 10 before printing otherwise < 0.1 BTC values were causing octal number error due to leading 0.